### PR TITLE
Release 0.4.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+* claferwiki Version 0.4.4 released on Jun 23, 2016
+
+[Release](https://github.com/gsdlab/claferwiki/pull/15)
+
 * claferwiki Version 0.4.3 released on Dec 22, 2015
 
 [Release](https://github.com/gsdlab/claferwiki/pull/14)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claferwiki
 
-##### v0.4.3
+##### v0.4.4
 
 **Claferwiki** is a wiki system integrated with [Clafer compiler](https://github.com/gsdlab/clafer). [Clafer](http://clafer.org) is a lightweight yet powerful structural modeling language. Claferwiki allows for embedding Clafer model fragments in wiki pages and provides model authoring support including code highlighting, parse and semantic error reporting, hyperlinking from identifier use to its definition, and graphical view rendering.
 
@@ -35,15 +35,15 @@ Clafer can be installed either from Hackage or from the source code.
 
 Regardless of the installation method, the following are required:
 
-* [Clafer compiler](https://github.com/gsdlab/clafer/) v0.4.3
-* [GHC](https://www.haskell.org/downloads) v7.10.*
+* [Clafer compiler](https://github.com/gsdlab/clafer/) v0.4.4
+* [GHC](https://www.haskell.org/downloads) >= v7.10.*
 * [Git](http://git-scm.com)
-* [Gitit wiki](http://gitit.net) v0.12.0.1
+* [Gitit wiki](http://gitit.net) v0.12.1.1
 * GraphViz
 
 ### Installation from Hackage
 
-Claferwiki is now available on [Hackage](http://hackage.haskell.org/package/claferwiki-0.4.3/) and it can be installed using either [`stack`](https://github.com/commercialhaskell/stack) or [`cabal-install`](https://hackage.haskell.org/package/cabal-install).
+Claferwiki is now available on [Hackage](http://hackage.haskell.org/package/claferwiki-0.4.4/) and it can be installed using either [`stack`](https://github.com/commercialhaskell/stack) or [`cabal-install`](https://hackage.haskell.org/package/cabal-install).
 
 #### Installation using `stack`
 
@@ -55,8 +55,8 @@ Stack is the only requirement: no other Haskell tooling needs to be installed be
 #### Installation using `cabal-install`
 
 1. `cabal update`
-2. `cabal install claferwiki-0.4.3 -fhighlighting -fhttps -fplugins -fnetwork-uri`
-3. `cd <cabal's lib or share folder>`  (`C:\Users\<user>\AppData\Roaming\cabal\i386-windows-ghc-7.10.2\claferwiki-0.4.3` on Windows or `.cabal/share/x86_64-linux-ghc-7.10.2/claferwiki-0.4.3/` on Linux)
+2. `cabal install claferwiki-0.4.4 -fhighlighting -fhttps -fplugins -fnetwork-uri`
+3. `cd <cabal's lib or share folder>`  (`C:\Users\<user>\AppData\Roaming\cabal\i386-windows-ghc-8.0.1\claferwiki-0.4.4` on Windows or `.cabal/share/x86_64-linux-ghc-8.0.1/claferwiki-0.4.4/` on Linux)
   * execute `make install to=<target directory>`
   * this will copy the wiki files
 

--- a/claferwiki.cabal
+++ b/claferwiki.cabal
@@ -1,5 +1,5 @@
 Name:                   claferwiki
-version:                0.4.3
+version:                0.4.4
 stability:              experimental
 author:                 Michał Antkiewicz, Chris Walker, Luke Michael Brown
 maintainer:             Michał Antkiewicz <mantkiew@gsd.uwaterloo.ca>
@@ -7,16 +7,13 @@ synopsis:               A wiki-based IDE for literate modeling with Clafer
 description:            A wiki-based IDE for literate modeling with Clafer. A Plugin for the Gitit wiki which collects code blocks written in Clafer (.clafer), compiles them, renders into HTML and Dot, and replaces the code blocks with the results.
 homepage:               http://github.com/gsdlab/claferwiki
 category:               Wiki
-cabal-version:          >= 1.18
 build-type:             Simple
 copyright:              Michal Antkiewicz, Chris Walker, Luke Michael Brown
 license:                MIT
 license-file:           LICENSE
-tested-with:            GHC == 7.8.3
-                      , GHC == 7.8.4
-                      , GHC == 7.10.1
-                      , GHC == 7.10.2
-                      , GHC == 7.10.3
+Tested-with:            GHC == 7.10.3
+                      , GHC == 8.0.1
+Cabal-version:          >= 1.22
 data-files:             claferwiki.sh
                       , gitit.cnf
                       , Makefile
@@ -31,7 +28,7 @@ source-repository head
     type:               git
     location:           git://github.com/gsdlab/claferwiki.git
 library
-  build-tools  :        ghc >= 7.8.3
+  build-tools  :        ghc >= 7.10.3
   default-language:     Haskell2010
   build-depends:        base >= 4.7.0.1 && < 5
                       , containers >= 0.5.5.1
@@ -49,9 +46,9 @@ library
                       , SHA >= 1.6.4.2
                       , utf8-string >= 0.3.8
                       , gitit >= 0.12.0.1
-                      , transformers-compat >= 0.3 && < 0.5
+                      , transformers-compat >= 0.3
 
-                      , clafer == 0.4.3
+                      , clafer == 0.4.4
   hs-source-dirs:       src
   ghc-options:          -Wall -fno-warn-orphans
   exposed-modules:      Network.Gitit.Plugin.ClaferWiki

--- a/claferwiki.sh
+++ b/claferwiki.sh
@@ -1,5 +1,5 @@
 echo "-----------------------------------------"
-echo "| ClaferWiki v0.4.3                     |"
+echo "| ClaferWiki v0.4.4                     |"
 echo "| https://github.com/gsdlab/claferwiki/ |"
 echo "| By Michal Antkiewicz, Chris Walker    |"
 echo "| Generative Software Development Lab   |"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,24 @@
-# for GHC-7.10.2
-extra-deps:
-  [ data-stringmap-1.0.1.1
-  , gitit-0.12.0.1
-  , filestore-0.6.1
-  , recaptcha-0.1.0.3
-  , uri-0.1.6.3
-  , sendfile-0.7.9
-  , clafer-0.4.3
-  ]
+# For GHC-8.0.1 (does not build yet)
+# extra-deps:
+#   - data-stringmap-1.0.1.1
+#   - json-builder-0.3
+#   - gitit-0.12.1.1
+#   - sendfile-0.7.9
+#   - filestore-0.6.2
+#   - json-0.9.1
+#   - recaptcha-0.1.0.3
+#   - uri-0.1.6.4
+# resolver: nightly-2016-06-21
 
-resolver: lts-3.19
+# for GHC-7.10.3
+extra-deps:
+  - data-stringmap-1.0.1.1
+  - gitit-0.12.1.1
+  - filestore-0.6.2
+  - recaptcha-0.1.0.3
+  - uri-0.1.6.4
+  - sendfile-0.7.9
+resolver: lts-6.4
 
 flags:
   sendfile:
@@ -21,4 +30,5 @@ flags:
     highlighting: true
 
 packages:
+- '../clafer'
 - '.'

--- a/templates/footer.st
+++ b/templates/footer.st
@@ -1,1 +1,1 @@
-<div id="footer">powered by <a href="http://github.com/jgm/gitit/tree/master/">gitit-0.12.0.1</a> and <a href="https://github.com/gsdlab/clafer">clafer-0.4.3</a></div>
+<div id="footer">powered by <a href="http://github.com/jgm/gitit/tree/master/">gitit-0.12.1.1</a> and <a href="https://github.com/gsdlab/clafer">clafer-0.4.4</a></div>


### PR DESCRIPTION
* compatibility with `clafer-0.4.4` and the latest `gitit-0.12.1.1`
* support only GHC >= 7.10.3 